### PR TITLE
Ensure trial and kinematic timestamps share session clock

### DIFF
--- a/data-manager.js
+++ b/data-manager.js
@@ -6,6 +6,13 @@ AFRAME.registerComponent('data-manager', {
         this.currentDecisionTime = 0;
         this.currentMovementTime = 0;
         this.totalTrials = 352;
+        this.sessionStartTime = null;
+        this.pendingTrialTimestamp = null;
+        this.kinematicData = {
+            left: [],
+            right: []
+        };
+        this.recordingActive = false;
         this.setupManualExport();
     },
     
@@ -52,9 +59,17 @@ AFRAME.registerComponent('data-manager', {
         }
     },
     
+    getSessionTimestamp: function() {
+        if (this.sessionStartTime === null) {
+            return 0;
+        }
+        return Date.now() - this.sessionStartTime;
+    },
+
     startDecisionTimer: function() {
         this.sphereAppearTime = Date.now();
         this.currentDecisionTime = 0;
+        this.pendingTrialTimestamp = this.getSessionTimestamp();
     },
     
     stopDecisionTimer: function() {
@@ -73,6 +88,7 @@ AFRAME.registerComponent('data-manager', {
         this.trialNumber++;
         this.trialData.push({
             trial: this.trialNumber,
+            timestamp: this.pendingTrialTimestamp !== null ? this.pendingTrialTimestamp : this.getSessionTimestamp(),
             target: targetPosition + 1, // Convert 0-10 to 1-11
             hand: handUsed,
             points: points,
@@ -80,14 +96,15 @@ AFRAME.registerComponent('data-manager', {
             decisionTime: decisionTime,
             totalMovementTime: this.currentMovementTime
         });
-        
+
         console.log(`Trial ${this.trialNumber}: Target ${targetPosition + 1}, Hand ${handUsed}, Points ${points}, Type ${hitType}, Decision Time ${decisionTime}ms`);
-        
+
         // Reset timer for next trial
         this.sphereAppearTime = 0;
         this.currentDecisionTime = 0;
         this.currentMovementTime = 0;
-        
+        this.pendingTrialTimestamp = null;
+
         // Check if session complete (110 trials)
         if (this.trialNumber >= this.totalTrials) {
             setTimeout(() => {
@@ -100,21 +117,23 @@ AFRAME.registerComponent('data-manager', {
         if (this.trialData.length === 0) {
             return;
         }
-        
+
+        this.stopSession();
+
         // Generate CSV content
-        let csvContent = 'Trial,Target,Hand,Points,HitType,DecisionTime,TotalMovementTime\n';
-        
+        let csvContent = 'Trial,Timestamp,Target,Hand,Points,HitType,DecisionTime,TotalMovementTime\n';
+
         this.trialData.forEach(trial => {
-            csvContent += `${trial.trial},${trial.target},${trial.hand},${trial.points},${trial.hitType},${trial.decisionTime},${trial.totalMovementTime}\n`;
+            csvContent += `${trial.trial},${trial.timestamp},${trial.target},${trial.hand},${trial.points},${trial.hitType},${trial.decisionTime},${trial.totalMovementTime}\n`;
         });
-        
+
         // Create and download CSV file
         const blob = new Blob([csvContent], { type: 'text/csv' });
         const url = URL.createObjectURL(blob);
-        
+
         const timestamp = new Date().toISOString().slice(0, 19).replace(/:/g, '-');
         const filename = `vr-session-data-${timestamp}.csv`;
-        
+
         const link = document.createElement('a');
         link.href = url;
         link.download = filename;
@@ -123,10 +142,72 @@ AFRAME.registerComponent('data-manager', {
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
-        
+
         URL.revokeObjectURL(url);
+
+        this.exportKinematicCSVs(timestamp);
     },
-    
+
+    exportKinematicCSVs: function(timestamp) {
+        const hands = ['left', 'right'];
+
+        hands.forEach(hand => {
+            const data = this.kinematicData[hand];
+            if (!data || data.length === 0) {
+                return;
+            }
+
+            let csvContent = 'Timestamp,X,Y,Z\n';
+            data.forEach(entry => {
+                csvContent += `${entry.timestamp},${entry.x},${entry.y},${entry.z}\n`;
+            });
+
+            const blob = new Blob([csvContent], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const filename = `kinematics-${hand}-${timestamp}.csv`;
+
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = filename;
+            link.style.display = 'none';
+
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+
+            URL.revokeObjectURL(url);
+        });
+    },
+
+    startSession: function() {
+        if (this.sessionStartTime === null) {
+            this.sessionStartTime = Date.now();
+        }
+        this.recordingActive = true;
+    },
+
+    stopSession: function() {
+        this.recordingActive = false;
+    },
+
+    recordKinematicData: function(hand, position) {
+        if (!this.recordingActive || this.sessionStartTime === null) {
+            return;
+        }
+
+        if (!position || position.x === undefined || position.y === undefined || position.z === undefined) {
+            return;
+        }
+
+        const timestamp = this.getSessionTimestamp();
+        this.kinematicData[hand].push({
+            timestamp: timestamp,
+            x: position.x,
+            y: position.y,
+            z: position.z
+        });
+    },
+
     updateTotalTrials: function(newTotal) {
         this.totalTrials = newTotal;
     },
@@ -138,5 +219,12 @@ AFRAME.registerComponent('data-manager', {
     resetSession: function() {
         this.trialData = [];
         this.trialNumber = 0;
+        this.sessionStartTime = null;
+        this.pendingTrialTimestamp = null;
+        this.kinematicData = {
+            left: [],
+            right: []
+        };
+        this.recordingActive = false;
     }
 });

--- a/sphere-manager.js
+++ b/sphere-manager.js
@@ -172,20 +172,40 @@ AFRAME.registerComponent('sphere-manager', {
     },
     
     resumeGame: function() {
+        const dataManagerEl = document.querySelector('#data-manager');
+        if (dataManagerEl && dataManagerEl.components['data-manager']) {
+            // Starting the session here ensures the session clock and kinematic
+            // capture begin as soon as the player presses P to resume.
+            dataManagerEl.components['data-manager'].startSession();
+        }
         this.isPaused = false;
     },
-    
+
     tick: function() {
         if (!this.isPaused) {
             const leftRectanglePos = this.leftRectangle.getAttribute('position');
             const rightRectanglePos = this.rightRectangle.getAttribute('position');
             const leftController = this.leftController;
             const rightController = this.rightController;
-            
+            const dataManagerEl = document.querySelector('#data-manager');
+            const dataManager = dataManagerEl ? dataManagerEl.components['data-manager'] : null;
+
+            const leftPos = leftController ? this.getHandPosition(leftController) : null;
+            const rightPos = rightController ? this.getHandPosition(rightController) : null;
+
+            if (dataManager) {
+                // Continuously log hand positions so the exported kinematic CSV
+                // shares the same timestamp reference as the per-trial data.
+                if (leftPos) {
+                    dataManager.recordKinematicData('left', leftPos);
+                }
+                if (rightPos) {
+                    dataManager.recordKinematicData('right', rightPos);
+                }
+            }
+
             if (this.currentState === 'invisible') {
                 if (leftController && rightController) {
-                    const leftPos = this.getHandPosition(leftController);
-                    const rightPos = this.getHandPosition(rightController);
                     if (leftPos && rightPos && this.isInsideRectangle(leftPos, leftRectanglePos) && this.isInsideRectangle(rightPos, rightRectanglePos)) {
                         if (!this.appearTimer) {
                             this.selectRandomSphere();
@@ -197,11 +217,9 @@ AFRAME.registerComponent('sphere-manager', {
                     }
                 }
             }
-            
+
             if (this.currentState === 'waiting-to-appear') {
                 if (leftController && rightController) {
-                    const leftPos = this.getHandPosition(leftController);
-                    const rightPos = this.getHandPosition(rightController);
                     if (!leftPos || !rightPos || !this.isInsideRectangle(leftPos, leftRectanglePos) || !this.isInsideRectangle(rightPos, rightRectanglePos)) {
                         clearTimeout(this.appearTimer);
                         this.appearTimer = null;
@@ -213,23 +231,22 @@ AFRAME.registerComponent('sphere-manager', {
             
             if (this.currentState === 'visible' && this.activeSphere) {
                 const spherePos = this.activeSphere.getAttribute('position');
-                const leftPos = this.getHandPosition(leftController);
-                const rightPos = this.getHandPosition(rightController);
-                
+
                 let leftHit = leftPos && this.isInsideSphere(leftPos, spherePos);
                 let rightHit = rightPos && this.isInsideSphere(rightPos, spherePos);
-                
+
                 if (!this.decisionTimeRecorded && leftPos && rightPos) {
                     const leftInRect = this.isInsideRectangle(leftPos, leftRectanglePos);
                     const rightInRect = this.isInsideRectangle(rightPos, rightRectanglePos);
                     
                     if (!leftInRect || !rightInRect) {
-                        const dataManager = document.querySelector('#data-manager').components['data-manager'];
-                        dataManager.stopDecisionTimer();
+                        if (dataManager) {
+                            dataManager.stopDecisionTimer();
+                        }
                         this.decisionTimeRecorded = true;
                     }
                 }
-                
+
                 if ((leftHit || rightHit) && !this.disappearTimer) {
                     this.activeSphere.setAttribute('color', '#0000ff');
                     
@@ -243,10 +260,11 @@ AFRAME.registerComponent('sphere-manager', {
                     this.createFloatingNumber(spherePos, hitResult.points, hitResult.hitType);
                     
                     const sphereIndex = this.allSpheres.indexOf(this.activeSphere);
-                    const dataManager = document.querySelector('#data-manager').components['data-manager'];
-                    dataManager.calculateAndStoreMovementTime();
-                    dataManager.recordTrial(sphereIndex, handUsed, hitResult.points, hitResult.hitType, dataManager.currentDecisionTime);
-                    
+                    if (dataManager) {
+                        dataManager.calculateAndStoreMovementTime();
+                        dataManager.recordTrial(sphereIndex, handUsed, hitResult.points, hitResult.hitType, dataManager.currentDecisionTime);
+                    }
+
                     this.startDisappearTimer();
                     this.currentState = 'waiting-to-disappear';
                 }


### PR DESCRIPTION
## Summary
- add a shared session timestamp helper so vr-session-data rows and kinematic samples line up to the same start time
- clarify in sphere-manager how session start ties kinematic capture to the timestamp clock

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e686f32ff48332a6d6746d81771eda